### PR TITLE
sign out functionality finished

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -105,25 +105,10 @@ export const createUser = newUser => {
   };
 };
 
-export const logOutUser = (loginSuccess) => {
+export const signOutUser = () => {
   return {
     type: "LOG_OUT_USER",
-    loginSuccess
-  }
-}
-
-export const createUserSignOut = (createUserSuccess) => {
-  return {
-    type: "CREATE_USER_SIGNOUT",
-    createUserSuccess
-  }
-}
-
-export const signOutUser = (loginSuccess, createUserSuccess) => {
-  return dispatch => {
-    loginSuccess = '';
-    createUserSuccess = {};
-    dispatch(createUserSignOut(createUserSuccess));
-    dispatch(logOutUser(loginSuccess));
+    loginSuccess: '',
+    createUserSuccess: {status: ''}
   }
 }

--- a/app/components/navheader/NavHeader.js
+++ b/app/components/navheader/NavHeader.js
@@ -20,13 +20,13 @@ export default class NavHeader extends Component {
             Home
           </NavLink>
 
-          {loginSuccess !== "success" && createUserSuccess !== 'success' && (
+          {(loginSuccess !== "success" && createUserSuccess !== 'success') && (
             <NavLink activeClassName="selected" className="nav" to="/login">
               Login
             </NavLink>
           )}
 
-          {createUserSuccess !== "success" && loginSuccess !== 'success' && (
+          {(createUserSuccess !== "success" && loginSuccess !== 'success') && (
             <NavLink
               activeClassName="selected"
               className="nav"

--- a/app/containers/navHeaderContainer.js
+++ b/app/containers/navHeaderContainer.js
@@ -2,17 +2,26 @@ import { connect } from 'react-redux';
 import NavHeader from '../components/navheader/NavHeader';
 import { signOutUser } from '../actions';
 
-const mapStateToProps = (store) => {
-  return {
-    loginSuccess: store.loginSuccess,
-    createUserSuccess: store.createUserSuccess.status
-  }
-}
+// logOutUser,
+// createUserSignOut
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    handleSignOut: () => dispatch(signOutUser())
-  }
-}
+const mapStateToProps = store => {
+	return {
+		loginSuccess:
+			store.logOutUser !== ''
+        ? store.loginSuccess
+        : store.logOutUser,
+		createUserSuccess:
+			store.createUserSignOut.status !== ''
+				? store.createUserSuccess.status
+				: store.createUserSignOut
+	};
+};
 
-export default connect(mapStateToProps, mapDispatchToProps)(NavHeader)
+const mapDispatchToProps = dispatch => {
+	return {
+		handleSignOut: () => dispatch(signOutUser())
+	};
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(NavHeader);

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -3,6 +3,7 @@ import { loginSuccess, loginHasErred } from "./login-reducer";
 import { fetchHasErred, fetchIsLoading, fetchDataSuccess } from './fetch-reducers';
 import { syncHistoryWithStore, routerReducer } from 'react-router-redux'
 import { createUserErred, createUserSuccess } from './create-user-reducer'
+import { logOutUser, createUserSignOut } from './sign-out-reducer'
 
 const rootReducer = combineReducers({
   loginSuccess,
@@ -12,7 +13,9 @@ const rootReducer = combineReducers({
   fetchDataSuccess,
   routing: routerReducer,
   createUserSuccess,
-  createUserErred
+  createUserErred,
+  logOutUser,
+  createUserSignOut
 });
 
 export default rootReducer;

--- a/app/reducers/sign-out-reducer.js
+++ b/app/reducers/sign-out-reducer.js
@@ -1,19 +1,19 @@
 export const logOutUser = (state = 'success', action) => {
-  switch (action.type) {
-    case 'LOG_OUT_USER':
-      return action.loginSuccess
+	switch (action.type) {
+		case 'LOG_OUT_USER':
+			return action.loginSuccess;
 
-    default:
-      return state
-  }
-}
+		default:
+			return state;
+	}
+};
 
-export const createUserSignOut = (state = {status: 'success'}, action) => {
-  switch (action.type) {
-    case 'CREATE_USER_SIGNOUT':
-      return action.createUserSuccess
+export const createUserSignOut = (state = { status: 'success' }, action) => {
+	switch (action.type) {
+		case 'LOG_OUT_USER':
+			return action.createUserSuccess;
 
-    default:
-      return state
-  }
-}
+		default:
+			return state;
+	}
+};


### PR DESCRIPTION
Changed to one action that returns an object with both login and create new user success and calls 2 reducers with the same TYPE. Ternary in navHeaderContainer for what we're passing down as props by checking if the logout or createNewUserSignout is not an empty string. 